### PR TITLE
Implement add_node extraction and ExtractedNode model

### DIFF
--- a/docs/flow-diagrams.md
+++ b/docs/flow-diagrams.md
@@ -1,0 +1,87 @@
+# Noctyl flow diagrams
+
+This document collects flow and architecture diagrams for the Noctyl pipeline. All diagrams use Mermaid and can be rendered on GitHub or in any Mermaid-capable viewer.
+
+**Maintenance:** Keep this document in sync with the codebase. When adding or changing pipeline steps (e.g. edge extraction, entry point, compile, repo scanner), add or update the corresponding diagram and section here.
+
+---
+
+## 1. LangGraph ingestion pipeline (Phase-1)
+
+End-to-end flow from Python source to extracted graph structure.
+
+```mermaid
+flowchart LR
+  subgraph input [Input]
+    Source[Python source]
+  end
+  subgraph ingestion [Ingestion]
+    Detector[langgraph_detector]
+    Tracker[stategraph_tracker]
+    Extractor[node_extractor]
+    Source --> Detector
+    Detector -->|file_contains_langgraph / has_langgraph_import| Tracker
+    Tracker -->|TrackedStateGraph list| Extractor
+    Extractor -->|graph_id to ExtractedNode list| Out
+  end
+  subgraph graph [Graph model]
+    EN[ExtractedNode]
+  end
+  Extractor -.->|uses| EN
+  subgraph output [Output]
+    Out[dict graph_id to nodes]
+  end
+```
+
+**Steps:**
+1. **langgraph_detector** — File-level check: does this file contain LangGraph? (`file_contains_langgraph`, `has_langgraph_import`).
+2. **stategraph_tracker** — Find every `StateGraph(...)` and track variable name and `graph_id` per instance.
+3. **node_extractor** — For each tracked graph, find `add_node(name, callable)` calls whose receiver resolves to that graph; emit `ExtractedNode(name, callable_ref, line)` per graph.
+
+---
+
+## 2. Node extraction flow
+
+How add_node calls are attributed to tracked StateGraph instances.
+
+```mermaid
+flowchart LR
+  subgraph ingestion [Ingestion]
+    ST[stategraph_tracker]
+    NE[node_extractor]
+    ST -->|TrackedStateGraph list| NE
+    NE -->|graph_id to ExtractedNode list| OUT[dict]
+  end
+  subgraph graph [Graph]
+    EN[ExtractedNode]
+  end
+  NE -.->|uses| EN
+```
+
+**Data flow:**
+- **Input:** `(source, file_path, list[TrackedStateGraph])`.
+- **Same-file alias resolution:** Build `name -> root` so that `h = g` and `g` = StateGraph variable implies `h.add_node(...)` is attributed to `g`’s `graph_id`.
+- **Output:** `dict[graph_id, list[ExtractedNode]]` with `ExtractedNode(name, callable_ref, line)`.
+
+---
+
+## 3. Detection and tracking (file-level)
+
+How we decide a file has LangGraph and how we get graph instances.
+
+```mermaid
+flowchart TB
+  Source[Python source] --> Parse[ast.parse]
+  Parse --> ImportCheck[Import check]
+  ImportCheck -->|has_langgraph_import| Track[track_stategraph_instances]
+  Track -->|list TrackedStateGraph| Instances[graph_id per instance]
+  ImportCheck -->|no langgraph.graph import| Skip[Skip file]
+  Parse -->|SyntaxError| Empty[return empty / False]
+```
+
+- **Fast path:** `has_langgraph_import(source)` — one AST pass over imports; use to skip files with no `langgraph.graph` import.
+- **Full check:** `file_contains_langgraph(source)` uses `track_stategraph_instances`; True iff at least one `StateGraph(...)` is found.
+
+---
+
+*Add new flow diagrams to this document as the pipeline grows (edges, entry/exit, compile, etc.).*

--- a/noctyl/graph/__init__.py
+++ b/noctyl/graph/__init__.py
@@ -1,0 +1,7 @@
+"""Workflow graph construction."""
+
+from noctyl.graph.nodes import ExtractedNode
+
+__all__ = [
+    "ExtractedNode",
+]

--- a/noctyl/graph/nodes.py
+++ b/noctyl/graph/nodes.py
@@ -1,0 +1,14 @@
+"""Node types for workflow graph."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExtractedNode:
+    """A node extracted from an add_node(name, callable) call."""
+
+    name: str
+    callable_ref: str
+    line: int = 0

--- a/noctyl/ingestion/__init__.py
+++ b/noctyl/ingestion/__init__.py
@@ -4,6 +4,7 @@ from noctyl.ingestion.langgraph_detector import (
     file_contains_langgraph,
     has_langgraph_import,
 )
+from noctyl.ingestion.node_extractor import extract_add_node_calls
 from noctyl.ingestion.stategraph_tracker import (
     TrackedStateGraph,
     track_stategraph_instances,
@@ -11,6 +12,7 @@ from noctyl.ingestion.stategraph_tracker import (
 
 __all__ = [
     "TrackedStateGraph",
+    "extract_add_node_calls",
     "file_contains_langgraph",
     "has_langgraph_import",
     "track_stategraph_instances",

--- a/noctyl/ingestion/node_extractor.py
+++ b/noctyl/ingestion/node_extractor.py
@@ -1,0 +1,148 @@
+"""
+Extract LangGraph nodes from add_node(name, callable) calls.
+
+Uses AST and tracked StateGraph instances to attribute each add_node call
+to a graph and extract node name and callable reference (string only).
+"""
+
+from __future__ import annotations
+
+import ast
+
+from noctyl.graph.nodes import ExtractedNode
+from noctyl.ingestion.stategraph_tracker import TrackedStateGraph
+
+
+def _build_alias_map(
+    tree: ast.AST,
+    roots: set[str],
+) -> dict[str, str]:
+    """
+    Build same-file alias map: name -> root variable name.
+    Roots are tracked StateGraph variable names. Only handles x = y (y is Name).
+    """
+    alias_map: dict[str, str] = {}
+    assigns: list[tuple[int, str, str]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and isinstance(node.value, ast.Name):
+                line = getattr(node, "lineno", 0) or 0
+                assigns.append((line, target.id, node.value.id))
+
+    for _line, lhs, rhs in sorted(assigns, key=lambda t: t[0]):
+        root = rhs if rhs in roots else alias_map.get(rhs)
+        if root is not None:
+            alias_map[lhs] = root
+
+    return alias_map
+
+
+def _resolve_receiver(
+    receiver: ast.expr,
+    roots: set[str],
+    alias_map: dict[str, str],
+) -> str | None:
+    """Resolve receiver to a root graph variable name, or None."""
+    if not isinstance(receiver, ast.Name):
+        return None
+    name = receiver.id
+    if name in roots:
+        return name
+    return alias_map.get(name)
+
+
+def _node_name_from_arg(node: ast.expr) -> str:
+    """Extract node name string from first positional arg."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return repr(node)
+
+
+def _callable_ref_from_arg(node: ast.expr) -> str:
+    """Extract callable reference as string only (no inspection of internals)."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        try:
+            return ast.unparse(node)
+        except Exception:
+            return "<attribute>"
+    if isinstance(node, ast.Lambda):
+        return "lambda"
+    return "<unknown>"
+
+
+def extract_add_node_calls(
+    source: str,
+    file_path: str,
+    tracked_graphs: list[TrackedStateGraph],
+) -> dict[str, list[ExtractedNode]]:
+    """
+    Extract all add_node(name, callable) calls and attribute them to tracked graphs.
+
+    - source: file contents
+    - file_path: path for this file (unused for extraction; for future use)
+    - tracked_graphs: list of TrackedStateGraph for this file (from track_stategraph_instances)
+
+    Returns dict mapping graph_id to list of ExtractedNode (name, callable_ref, line).
+    Only add_node calls whose receiver resolves to a tracked graph variable are included.
+    On SyntaxError returns {}.
+    """
+    result: dict[str, list[ExtractedNode]] = {
+        t.graph_id: [] for t in tracked_graphs
+    }
+
+    if not tracked_graphs:
+        return result
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return {}
+
+    roots: set[str] = set()
+    graph_id_by_var: dict[str, str] = {}
+    for t in tracked_graphs:
+        if t.variable_name is not None:
+            roots.add(t.variable_name)
+            graph_id_by_var[t.variable_name] = t.graph_id
+
+    if not roots:
+        return result
+
+    alias_map = _build_alias_map(tree, roots)
+
+    add_node_calls: list[tuple[str, ast.Call]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr != "add_node":
+                continue
+            receiver = node.func.value
+            root = _resolve_receiver(receiver, roots, alias_map)
+            if root is None:
+                continue
+            graph_id = graph_id_by_var.get(root)
+            if graph_id is None:
+                continue
+            if len(node.args) < 2:
+                continue
+            add_node_calls.append((graph_id, node))
+
+    for graph_id, call in add_node_calls:
+        name = _node_name_from_arg(call.args[0])
+        callable_ref = _callable_ref_from_arg(call.args[1])
+        line = getattr(call, "lineno", 0) or 0
+        result[graph_id].append(
+            ExtractedNode(name=name, callable_ref=callable_ref, line=line)
+        )
+
+    for graph_id in result:
+        result[graph_id].sort(key=lambda n: n.line)
+
+    return result

--- a/tests/test_node_extractor.py
+++ b/tests/test_node_extractor.py
@@ -1,0 +1,183 @@
+"""Tests for add_node extraction."""
+
+from noctyl.graph.nodes import ExtractedNode
+from noctyl.ingestion.node_extractor import extract_add_node_calls
+from noctyl.ingestion.stategraph_tracker import track_stategraph_instances
+
+
+def _extract(source: str, file_path: str = "file.py"):
+    tracked = track_stategraph_instances(source, file_path)
+    return extract_add_node_calls(source, file_path, tracked)
+
+
+def test_one_graph_one_add_node():
+    """One graph, one add_node('name', func) -> node with correct name and callable_ref."""
+    source = """
+from langgraph.graph import StateGraph
+
+def my_node(state):
+    return state
+
+g = StateGraph(dict)
+g.add_node("agent", my_node)
+"""
+    result = _extract(source)
+    assert len(result) == 1
+    graph_id = list(result.keys())[0]
+    nodes = result[graph_id]
+    assert len(nodes) == 1
+    assert nodes[0].name == "agent"
+    assert nodes[0].callable_ref == "my_node"
+    assert nodes[0].line > 0
+
+
+def test_one_graph_multiple_add_node():
+    """One graph, multiple add_node calls -> all extracted in order."""
+    source = """
+from langgraph.graph import StateGraph
+
+def a(s): return s
+def b(s): return s
+
+g = StateGraph(dict)
+g.add_node("first", a)
+g.add_node("second", b)
+"""
+    result = _extract(source)
+    assert len(result) == 1
+    nodes = result[list(result.keys())[0]]
+    assert len(nodes) == 2
+    assert nodes[0].name == "first" and nodes[0].callable_ref == "a"
+    assert nodes[1].name == "second" and nodes[1].callable_ref == "b"
+
+
+def test_aliased_receiver():
+    """g = StateGraph(...); h = g; h.add_node('n', f) -> node attributed to same graph_id."""
+    source = """
+from langgraph.graph import StateGraph
+
+def f(s): return s
+g = StateGraph(dict)
+h = g
+h.add_node("n", f)
+"""
+    result = _extract(source)
+    assert len(result) == 1
+    nodes = result[list(result.keys())[0]]
+    assert len(nodes) == 1
+    assert nodes[0].name == "n" and nodes[0].callable_ref == "f"
+
+
+def test_callable_ref_name():
+    """callable_ref from Name -> node.id."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+g.add_node("x", my_func)
+"""
+    result = _extract(source)
+    nodes = result[list(result.keys())[0]]
+    assert nodes[0].callable_ref == "my_func"
+
+
+def test_callable_ref_attribute():
+    """callable_ref from Attribute -> unparse or 'a.b'."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+g.add_node("x", mod.handler)
+"""
+    result = _extract(source)
+    nodes = result[list(result.keys())[0]]
+    assert nodes[0].callable_ref == "mod.handler"
+
+
+def test_callable_ref_lambda():
+    """callable_ref from Lambda -> 'lambda'."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+g.add_node("x", lambda s: s)
+"""
+    result = _extract(source)
+    nodes = result[list(result.keys())[0]]
+    assert nodes[0].callable_ref == "lambda"
+
+
+def test_no_add_node():
+    """No add_node calls -> empty lists per graph."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+"""
+    result = _extract(source)
+    assert len(result) == 1
+    assert result[list(result.keys())[0]] == []
+
+
+def test_non_stategraph_add_node_ignored():
+    """add_node on non-StateGraph receiver -> not attributed to our graph."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+other = SomeOtherClass()
+other.add_node("n", f)
+"""
+    result = _extract(source)
+    nodes = result[list(result.keys())[0]]
+    assert len(nodes) == 0
+
+
+def test_syntax_error_returns_empty():
+    """Syntax error -> empty dict."""
+    result = _extract("from langgraph.graph import StateGraph\n g = StateGraph( ", "x.py")
+    assert result == {}
+
+
+def test_empty_source_no_tracked_graphs():
+    """Empty source -> no tracked graphs, so extract returns {} or empty per-graph."""
+    result = _extract("")
+    assert result == {}
+
+
+def test_multiple_graphs_nodes_assigned_correctly():
+    """Multiple graphs in one file -> nodes assigned to correct graph_id by receiver."""
+    source = """
+from langgraph.graph import StateGraph
+a = StateGraph(dict)
+b = StateGraph(dict)
+a.add_node("from_a", fn1)
+b.add_node("from_b", fn2)
+"""
+    result = _extract(source)
+    assert len(result) == 2
+    graph_ids = sorted(result.keys())
+    by_id = {gid: [n.name for n in result[gid]] for gid in graph_ids}
+    assert "from_a" in by_id[graph_ids[0]] or "from_a" in by_id[graph_ids[1]]
+    assert "from_b" in by_id[graph_ids[0]] or "from_b" in by_id[graph_ids[1]]
+    for gid, nodes in result.items():
+        assert len(nodes) == 1
+        if nodes[0].name == "from_a":
+            assert nodes[0].callable_ref == "fn1"
+        else:
+            assert nodes[0].name == "from_b" and nodes[0].callable_ref == "fn2"
+
+
+def test_node_name_from_constant():
+    """Node name from string Constant."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+g.add_node("constant_name", f)
+"""
+    result = _extract(source)
+    nodes = result[list(result.keys())[0]]
+    assert nodes[0].name == "constant_name"
+
+
+def test_extracted_node_is_dataclass():
+    """ExtractedNode has name, callable_ref, line."""
+    node = ExtractedNode(name="n", callable_ref="f", line=10)
+    assert node.name == "n"
+    assert node.callable_ref == "f"
+    assert node.line == 10


### PR DESCRIPTION
## Summary
Implements extraction of LangGraph nodes from `add_node(name, callable)` calls per [add_node_extraction.md](.github/ISSUE_TEMPLATE/add_node_extraction.md). Adds a minimal graph model and an AST-based node extractor that attributes each add_node call to a tracked StateGraph.

## Changes
- **`noctyl/graph/`** (new package)
  - `nodes.py` — `ExtractedNode(name, callable_ref, line)` dataclass
  - `__init__.py` — exports `ExtractedNode`
- **`noctyl/ingestion/node_extractor.py`** (new)
  - `extract_add_node_calls(source, file_path, tracked_graphs)` → `dict[graph_id, list[ExtractedNode]]`
  - Same-file alias resolution so `h = g; h.add_node(...)` is attributed to `g`'s graph
  - Node name from first arg (string Constant or unparse); callable ref from second arg (Name / Attribute / Lambda / `<unknown>`)
- **`noctyl/ingestion/__init__.py`** — exports `extract_add_node_calls`
- **`tests/test_node_extractor.py`** — 13 tests (one/multiple add_node, aliased receiver, callable_ref types, no add_node, syntax error, multiple graphs, etc.)
- **`docs/flow-diagrams.md`** — new doc for pipeline flow diagrams; includes ingestion and node-extraction flows

## Acceptance criteria (from issue)
- [x] All add_node calls extracted (per tracked graph, same file)
- [x] Node metadata stored in a defined structure (`ExtractedNode`)

## Out of scope
- Inspecting callable internals (only string reference is extracted)

Closes #4