### PR TITLE
Add conditional edge extraction

### DIFF
--- a/noctyl/graph/__init__.py
+++ b/noctyl/graph/__init__.py
@@ -1,9 +1,10 @@
 """Workflow graph construction."""
 
-from noctyl.graph.edges import ExtractedEdge
+from noctyl.graph.edges import ExtractedEdge, ExtractedConditionalEdge
 from noctyl.graph.nodes import ExtractedNode
 
 __all__ = [
+    "ExtractedConditionalEdge",
     "ExtractedEdge",
     "ExtractedNode",
 ]

--- a/noctyl/graph/edges.py
+++ b/noctyl/graph/edges.py
@@ -12,3 +12,13 @@ class ExtractedEdge:
     source: str
     target: str
     line: int = 0
+
+
+@dataclass(frozen=True)
+class ExtractedConditionalEdge:
+    """A conditional edge extracted from add_conditional_edges path_map (one per mapping)."""
+
+    source: str
+    condition_label: str
+    target: str
+    line: int = 0

--- a/noctyl/ingestion/__init__.py
+++ b/noctyl/ingestion/__init__.py
@@ -4,7 +4,10 @@ from noctyl.ingestion.langgraph_detector import (
     file_contains_langgraph,
     has_langgraph_import,
 )
-from noctyl.ingestion.edge_extractor import extract_add_edge_calls
+from noctyl.ingestion.edge_extractor import (
+    extract_add_conditional_edges,
+    extract_add_edge_calls,
+)
 from noctyl.ingestion.node_extractor import extract_add_node_calls
 from noctyl.ingestion.stategraph_tracker import (
     TrackedStateGraph,
@@ -13,6 +16,7 @@ from noctyl.ingestion.stategraph_tracker import (
 
 __all__ = [
     "TrackedStateGraph",
+    "extract_add_conditional_edges",
     "extract_add_edge_calls",
     "extract_add_node_calls",
     "file_contains_langgraph",

--- a/noctyl/ingestion/edge_extractor.py
+++ b/noctyl/ingestion/edge_extractor.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import ast
 
-from noctyl.graph.edges import ExtractedEdge
+from noctyl.graph.edges import ExtractedEdge, ExtractedConditionalEdge
 from noctyl.ingestion.receiver_resolution import build_alias_map, resolve_receiver
 from noctyl.ingestion.stategraph_tracker import TrackedStateGraph
 
@@ -28,6 +28,39 @@ def _edge_arg_to_string(node: ast.expr) -> str:
         return ast.unparse(node)
     except Exception:
         return repr(node)
+
+
+def _condition_label_to_string(node: ast.expr) -> str:
+    """Stringify path_map key (condition label). Constant or unparse/repr."""
+    if isinstance(node, ast.Constant):
+        return str(node.value)
+    try:
+        return ast.unparse(node)
+    except Exception:
+        return repr(node)
+
+
+def _path_map_to_edges(
+    source_str: str,
+    path_map_node: ast.Dict,
+    line: int,
+) -> list[ExtractedConditionalEdge]:
+    """Build one ExtractedConditionalEdge per path_map entry (dict literal only)."""
+    result: list[ExtractedConditionalEdge] = []
+    keys = path_map_node.keys or []
+    values = path_map_node.values or []
+    for k, v in zip(keys, values):
+        label_str = _condition_label_to_string(k)
+        target_str = _edge_arg_to_string(v)
+        result.append(
+            ExtractedConditionalEdge(
+                source=source_str,
+                condition_label=label_str,
+                target=target_str,
+                line=line,
+            )
+        )
+    return result
 
 
 def extract_add_edge_calls(
@@ -98,5 +131,80 @@ def extract_add_edge_calls(
 
     for graph_id in result:
         result[graph_id].sort(key=lambda e: e.line)
+
+    return result
+
+
+def extract_add_conditional_edges(
+    source: str,
+    file_path: str,
+    tracked_graphs: list[TrackedStateGraph],
+) -> dict[str, list[ExtractedConditionalEdge]]:
+    """
+    Extract conditional edges from add_conditional_edges(source, path, path_map) calls.
+
+    Only path_map as a dict literal is supported; variable path_map is skipped (best-effort).
+    One ExtractedConditionalEdge per path_map key-value pair. END as value -> target "END".
+    On SyntaxError returns {}.
+    """
+    result: dict[str, list[ExtractedConditionalEdge]] = {
+        t.graph_id: [] for t in tracked_graphs
+    }
+
+    if not tracked_graphs:
+        return result
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return {}
+
+    roots: set[str] = set()
+    graph_id_by_var: dict[str, str] = {}
+    for t in tracked_graphs:
+        if t.variable_name is not None:
+            roots.add(t.variable_name)
+            graph_id_by_var[t.variable_name] = t.graph_id
+
+    if not roots:
+        return result
+
+    alias_map = build_alias_map(tree, roots)
+
+    cond_calls: list[tuple[str, ast.Call]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr != "add_conditional_edges":
+                continue
+            receiver = node.func.value
+            root = resolve_receiver(receiver, roots, alias_map)
+            if root is None:
+                continue
+            graph_id = graph_id_by_var.get(root)
+            if graph_id is None:
+                continue
+            if len(node.args) < 2:
+                continue
+            cond_calls.append((graph_id, node))
+
+    for graph_id, call in cond_calls:
+        source_str = _edge_arg_to_string(call.args[0])
+        path_map_node: ast.Dict | None = None
+        if len(call.args) >= 3 and isinstance(call.args[2], ast.Dict):
+            path_map_node = call.args[2]
+        else:
+            for kw in call.keywords or []:
+                if kw.arg == "path_map" and isinstance(kw.value, ast.Dict):
+                    path_map_node = kw.value
+                    break
+        if path_map_node is None:
+            continue
+        line = getattr(call, "lineno", 0) or 0
+        edges = _path_map_to_edges(source_str, path_map_node, line)
+        result[graph_id].extend(edges)
+
+    for graph_id in result:
+        result[graph_id].sort(key=lambda e: (e.line, e.condition_label))
 
     return result

--- a/tests/test_conditional_edges.py
+++ b/tests/test_conditional_edges.py
@@ -1,0 +1,152 @@
+"""Tests for add_conditional_edges extraction."""
+
+from noctyl.graph.edges import ExtractedConditionalEdge
+from noctyl.ingestion.edge_extractor import extract_add_conditional_edges
+from noctyl.ingestion.stategraph_tracker import track_stategraph_instances
+
+
+def _extract_conditional(source: str, file_path: str = "file.py"):
+    tracked = track_stategraph_instances(source, file_path)
+    return extract_add_conditional_edges(source, file_path, tracked)
+
+
+def test_one_conditional_edge_literal_path_map():
+    """Literal path_map with one entry -> one conditional edge."""
+    source = """
+from langgraph.graph import StateGraph, END
+g = StateGraph(dict)
+g.add_node("a", fa)
+g.add_conditional_edges("a", router, {"yes": "b", "no": END})
+"""
+    result = _extract_conditional(source)
+    assert len(result) == 1
+    edges = result[list(result.keys())[0]]
+    assert len(edges) == 2
+    by_label = {e.condition_label: e for e in edges}
+    assert by_label["yes"].source == "a" and by_label["yes"].target == "b"
+    assert by_label["no"].source == "a" and by_label["no"].target == "END"
+
+
+def test_condition_labels_preserved():
+    """Condition labels from path_map keys are preserved."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+g.add_conditional_edges("x", decide, {"continue": "next", "stop": "end_node"})
+"""
+    result = _extract_conditional(source)
+    edges = result[list(result.keys())[0]]
+    assert len(edges) == 2
+    labels = {e.condition_label for e in edges}
+    assert labels == {"continue", "stop"}
+    targets = {e.target for e in edges}
+    assert targets == {"next", "end_node"}
+
+
+def test_end_as_target():
+    """END as path_map value -> target is 'END' (terminal)."""
+    source = """
+from langgraph.graph import StateGraph, END
+g = StateGraph(dict)
+g.add_conditional_edges("n", r, {"done": END})
+"""
+    result = _extract_conditional(source)
+    edges = result[list(result.keys())[0]]
+    assert len(edges) == 1
+    assert edges[0].target == "END"
+    assert edges[0].condition_label == "done"
+
+
+def test_aliased_receiver():
+    """Conditional edges on aliased graph receiver -> attributed to same graph_id."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+h = g
+h.add_conditional_edges("src", path, {"a": "x"})
+"""
+    result = _extract_conditional(source)
+    assert len(result) == 1
+    edges = result[list(result.keys())[0]]
+    assert len(edges) == 1
+    assert edges[0].source == "src" and edges[0].condition_label == "a" and edges[0].target == "x"
+
+
+def test_no_path_map_literal_skipped():
+    """add_conditional_edges with only source and path (no path_map dict) -> no edges."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+g.add_conditional_edges("a", router)
+"""
+    result = _extract_conditional(source)
+    assert len(result) == 1
+    assert result[list(result.keys())[0]] == []
+
+
+def test_path_map_variable_skipped():
+    """path_map as variable (non-dict literal) -> skipped, no edges for that call."""
+    source = """
+from langgraph.graph import StateGraph
+g = StateGraph(dict)
+path_map = {"k": "v"}
+g.add_conditional_edges("a", router, path_map)
+"""
+    result = _extract_conditional(source)
+    assert len(result) == 1
+    assert result[list(result.keys())[0]] == []
+
+
+def test_multiple_graphs_conditional_assigned_correctly():
+    """Multiple graphs -> conditional edges assigned to correct graph_id."""
+    source = """
+from langgraph.graph import StateGraph
+a = StateGraph(dict)
+b = StateGraph(dict)
+a.add_conditional_edges("n1", r1, {"x": "y"})
+b.add_conditional_edges("n2", r2, {"p": "q"})
+"""
+    result = _extract_conditional(source)
+    assert len(result) == 2
+    all_edges = []
+    for edges in result.values():
+        all_edges.extend(edges)
+    assert len(all_edges) == 2
+    labels = {e.condition_label for e in all_edges}
+    assert labels == {"x", "p"}
+
+
+def test_syntax_error_returns_empty():
+    """Syntax error -> empty dict."""
+    result = _extract_conditional("from langgraph.graph import StateGraph\n g = StateGraph( ", "x.py")
+    assert result == {}
+
+
+def test_empty_source_no_tracked_graphs():
+    """Empty source -> no tracked graphs -> empty dict."""
+    result = _extract_conditional("")
+    assert result == {}
+
+
+def test_path_map_keyword_arg():
+    """path_map passed as keyword (dict literal) -> extracted."""
+    source = """
+from langgraph.graph import StateGraph, END
+g = StateGraph(dict)
+g.add_conditional_edges("a", router, path_map={"ok": "b", "finish": END})
+"""
+    result = _extract_conditional(source)
+    edges = result[list(result.keys())[0]]
+    assert len(edges) == 2
+    by_label = {e.condition_label: e for e in edges}
+    assert by_label["ok"].target == "b"
+    assert by_label["finish"].target == "END"
+
+
+def test_extracted_conditional_edge_dataclass():
+    """ExtractedConditionalEdge has source, condition_label, target, line."""
+    edge = ExtractedConditionalEdge(source="a", condition_label="l", target="b", line=10)
+    assert edge.source == "a"
+    assert edge.condition_label == "l"
+    assert edge.target == "b"
+    assert edge.line == 10

--- a/tests/test_ingestion_integration.py
+++ b/tests/test_ingestion_integration.py
@@ -5,7 +5,76 @@ One source file is run through the full ingestion pipeline; we assert all compon
 agree on graph presence, graph_id, and that nodes/edges belong to the same graph.
 """
 
+
+def test_full_system_sync_all_components():
+    """
+    Full system sync: detector, tracker, nodes, sequential edges, and conditional edges
+    all run on one workflow; same graph_id everywhere; nodes/edges/conditional edges consistent.
+    """
+    source = """
+from langgraph.graph import StateGraph, START, END
+
+def agent(s): return s
+def tool(s): return s
+def router(s): return "continue" if s else "stop"
+
+graph = StateGraph(dict)
+graph.add_node("agent", agent)
+graph.add_node("tool", tool)
+graph.add_edge(START, "agent")
+graph.add_edge("agent", "tool")
+graph.add_conditional_edges("tool", router, {"continue": "agent", "stop": END})
+"""
+    file_path = "app/full_workflow.py"
+
+    # 1. Detector
+    assert has_langgraph_import(source) is True
+    assert file_contains_langgraph(source, file_path) is True
+
+    # 2. Tracker: one graph
+    tracked = track_stategraph_instances(source, file_path)
+    assert len(tracked) == 1
+    graph_id = tracked[0].graph_id
+
+    # 3. Nodes: same graph_id, expected names
+    nodes_by_graph = extract_add_node_calls(source, file_path, tracked)
+    assert set(nodes_by_graph.keys()) == {graph_id}
+    nodes = nodes_by_graph[graph_id]
+    node_names = {n.name for n in nodes}
+    assert node_names == {"agent", "tool"}
+
+    # 4. Sequential edges: same graph_id
+    edges_by_graph = extract_add_edge_calls(source, file_path, tracked)
+    assert set(edges_by_graph.keys()) == {graph_id}
+    edges = edges_by_graph[graph_id]
+    assert len(edges) >= 2
+    edge_sources = {e.source for e in edges}
+    edge_targets = {e.target for e in edges}
+    assert "START" in edge_sources
+    assert "agent" in edge_sources or "agent" in edge_targets
+    assert "tool" in edge_targets or "tool" in edge_sources
+
+    # 5. Conditional edges: same graph_id
+    cond_by_graph = extract_add_conditional_edges(source, file_path, tracked)
+    assert set(cond_by_graph.keys()) == {graph_id}
+    cond_edges = cond_by_graph[graph_id]
+    assert len(cond_edges) == 2
+    cond_labels = {e.condition_label for e in cond_edges}
+    assert cond_labels == {"continue", "stop"}
+    for ce in cond_edges:
+        assert ce.source == "tool"
+        assert ce.target in ("agent", "END")
+
+    # 6. Cross-component consistency: conditional source is a node; targets are node or END
+    for ce in cond_edges:
+        assert ce.source in node_names
+        assert ce.target in node_names or ce.target == "END"
+    for e in edges:
+        assert e.source in node_names or e.source == "START"
+        assert e.target in node_names or e.target == "END"
+
 from noctyl.ingestion import (
+    extract_add_conditional_edges,
     extract_add_edge_calls,
     extract_add_node_calls,
     file_contains_langgraph,
@@ -118,3 +187,27 @@ b.add_edge("n2", "n2")
         assert len(edges) == 1
         assert edges[0].source == nodes[0].name
         assert edges[0].target == nodes[0].name
+
+
+def test_full_pipeline_with_conditional_edges():
+    """Pipeline with add_conditional_edges: conditional edges extracted for same graph_id."""
+    source = """
+from langgraph.graph import StateGraph, END
+graph = StateGraph(dict)
+graph.add_node("a", fa)
+graph.add_node("b", fb)
+graph.add_conditional_edges("a", router, {"go": "b", "stop": END})
+"""
+    file_path = "cond.py"
+    assert file_contains_langgraph(source, file_path) is True
+    tracked = track_stategraph_instances(source, file_path)
+    assert len(tracked) == 1
+    graph_id = tracked[0].graph_id
+
+    cond_by_graph = extract_add_conditional_edges(source, file_path, tracked)
+    assert set(cond_by_graph.keys()) == {graph_id}
+    cond_edges = cond_by_graph[graph_id]
+    assert len(cond_edges) == 2
+    by_label = {e.condition_label: e for e in cond_edges}
+    assert by_label["go"].source == "a" and by_label["go"].target == "b"
+    assert by_label["stop"].source == "a" and by_label["stop"].target == "END"


### PR DESCRIPTION
## Summary
Implements extraction of LangGraph conditional edges from `add_conditional_edges(source, path, path_map)` per [conditional_edges.md](.github/ISSUE_TEMPLATE/conditional_edges.md). One edge per path_map entry, condition labels preserved, END supported as terminal. Structure only (path_map must be a dict literal).

## Changes
- **`noctyl/graph/edges.py`** — `ExtractedConditionalEdge(source, condition_label, target, line)`.
- **`noctyl/graph/__init__.py`** — Export `ExtractedConditionalEdge`.
- **`noctyl/ingestion/edge_extractor.py`** — `extract_add_conditional_edges(source, file_path, tracked_graphs)`; `_path_map_to_edges`, `_condition_label_to_string`; path_map from 3rd positional or keyword `path_map` (dict literal only); variable path_map skipped.
- **`noctyl/ingestion/__init__.py`** — Export `extract_add_conditional_edges`.
- **`tests/test_conditional_edges.py`** (new) — 11 tests: literal path_map, labels, END, aliased receiver, no/variable path_map skipped, multiple graphs, keyword path_map.
- **`tests/test_ingestion_integration.py`** — `test_full_pipeline_with_conditional_edges`, `test_full_system_sync_all_components` (detector + tracker + nodes + sequential + conditional edges in sync).
- **`docs/flow-diagrams.md`** — Conditional edges in pipeline diagram and new “Conditional edges flow” section.

## Acceptance criteria (from issue)
- [x] Conditional edges extracted (one per path_map entry when path_map is dict literal).
- [x] Conditions labeled correctly (condition_label from path_map key).
- [x] END handled as terminal transition (target = "END").

## Limitation
- path_map as variable: not extracted (best-effort, structure only).

Closes #5