### PR TITLE
Define and document LangGraph scope and constraints

### DIFF
--- a/noctyl/graph/__init__.py
+++ b/noctyl/graph/__init__.py
@@ -1,10 +1,18 @@
 """Workflow graph construction."""
 
 from noctyl.graph.edges import ExtractedEdge, ExtractedConditionalEdge
+from noctyl.graph.graph import (
+    WorkflowGraph,
+    build_workflow_graph,
+    workflow_graph_to_dict,
+)
 from noctyl.graph.nodes import ExtractedNode
 
 __all__ = [
     "ExtractedConditionalEdge",
     "ExtractedEdge",
     "ExtractedNode",
+    "WorkflowGraph",
+    "build_workflow_graph",
+    "workflow_graph_to_dict",
 ]

--- a/noctyl/graph/graph.py
+++ b/noctyl/graph/graph.py
@@ -1,0 +1,78 @@
+"""
+Workflow graph data model and deterministic JSON serialization.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from noctyl.graph.edges import ExtractedConditionalEdge, ExtractedEdge
+from noctyl.graph.nodes import ExtractedNode
+
+DEFAULT_SCHEMA_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class WorkflowGraph:
+    """Aggregated workflow graph: nodes, directed edges, entry point."""
+
+    graph_id: str
+    nodes: tuple[ExtractedNode, ...]
+    edges: tuple[ExtractedEdge, ...]
+    conditional_edges: tuple[ExtractedConditionalEdge, ...]
+    entry_point: str | None
+    schema_version: str = DEFAULT_SCHEMA_VERSION
+
+
+def build_workflow_graph(
+    graph_id: str,
+    nodes: list[ExtractedNode],
+    edges: list[ExtractedEdge],
+    conditional_edges: list[ExtractedConditionalEdge],
+    entry_point: str | None,
+    schema_version: str = DEFAULT_SCHEMA_VERSION,
+) -> WorkflowGraph:
+    """Build a WorkflowGraph from ingestion outputs."""
+    return WorkflowGraph(
+        graph_id=graph_id,
+        nodes=tuple(nodes),
+        edges=tuple(edges),
+        conditional_edges=tuple(conditional_edges),
+        entry_point=entry_point,
+        schema_version=schema_version,
+    )
+
+
+def workflow_graph_to_dict(g: WorkflowGraph) -> dict:
+    """
+    Return a JSON-serializable dict with deterministic ordering.
+    Same WorkflowGraph -> same dict (and same JSON with sort_keys=True).
+    """
+    nodes_sorted = sorted(g.nodes, key=lambda n: (n.name, n.line))
+    edges_sorted = sorted(g.edges, key=lambda e: (e.source, e.target, e.line))
+    cond_sorted = sorted(
+        g.conditional_edges,
+        key=lambda e: (e.source, e.condition_label, e.target, e.line),
+    )
+    return {
+        "schema_version": g.schema_version,
+        "graph_id": g.graph_id,
+        "entry_point": g.entry_point,
+        "nodes": [
+            {"name": n.name, "callable_ref": n.callable_ref, "line": n.line}
+            for n in nodes_sorted
+        ],
+        "edges": [
+            {"source": e.source, "target": e.target, "line": e.line}
+            for e in edges_sorted
+        ],
+        "conditional_edges": [
+            {
+                "source": e.source,
+                "condition_label": e.condition_label,
+                "target": e.target,
+                "line": e.line,
+            }
+            for e in cond_sorted
+        ],
+    }

--- a/noctyl/graph/schema.json
+++ b/noctyl/graph/schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://noctyl.ai/schemas/workflow-graph-v1.json",
+  "title": "WorkflowGraph",
+  "description": "Noctyl Phase-1 workflow graph: nodes, directed edges, entry point.",
+  "type": "object",
+  "required": ["schema_version", "graph_id", "entry_point", "nodes", "edges", "conditional_edges"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Schema version (e.g. 1.0)."
+    },
+    "graph_id": {
+      "type": "string",
+      "description": "Stable identifier for this graph (e.g. file_path:ordinal)."
+    },
+    "entry_point": {
+      "oneOf": [{ "type": "string" }, { "type": "null" }],
+      "description": "Entry node name, or null if missing/unknown."
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "callable_ref", "line"],
+        "properties": {
+          "name": { "type": "string" },
+          "callable_ref": { "type": "string" },
+          "line": { "type": "integer" }
+        }
+      }
+    },
+    "edges": {
+      "type": "array",
+      "description": "Directed sequential edges.",
+      "items": {
+        "type": "object",
+        "required": ["source", "target", "line"],
+        "properties": {
+          "source": { "type": "string" },
+          "target": { "type": "string" },
+          "line": { "type": "integer" }
+        }
+      }
+    },
+    "conditional_edges": {
+      "type": "array",
+      "description": "Directed conditional edges (one per path_map entry).",
+      "items": {
+        "type": "object",
+        "required": ["source", "condition_label", "target", "line"],
+        "properties": {
+          "source": { "type": "string" },
+          "condition_label": { "type": "string" },
+          "target": { "type": "string" },
+          "line": { "type": "integer" }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -1,0 +1,159 @@
+"""Tests for WorkflowGraph schema and deterministic serialization."""
+
+import json
+
+from noctyl.graph import (
+    ExtractedConditionalEdge,
+    ExtractedEdge,
+    ExtractedNode,
+    WorkflowGraph,
+    build_workflow_graph,
+    workflow_graph_to_dict,
+)
+
+
+def test_workflow_graph_to_dict_structure():
+    """Serialized dict has schema_version, graph_id, entry_point, nodes, edges, conditional_edges."""
+    g = WorkflowGraph(
+        graph_id="file.py:0",
+        nodes=(ExtractedNode("a", "f", 10),),
+        edges=(ExtractedEdge("a", "b", 11),),
+        conditional_edges=(),
+        entry_point="a",
+    )
+    d = workflow_graph_to_dict(g)
+    assert d["schema_version"] == "1.0"
+    assert d["graph_id"] == "file.py:0"
+    assert d["entry_point"] == "a"
+    assert "nodes" in d and isinstance(d["nodes"], list)
+    assert "edges" in d and isinstance(d["edges"], list)
+    assert "conditional_edges" in d and isinstance(d["conditional_edges"], list)
+    assert len(d["nodes"]) == 1
+    assert d["nodes"][0] == {"name": "a", "callable_ref": "f", "line": 10}
+    assert len(d["edges"]) == 1
+    assert d["edges"][0] == {"source": "a", "target": "b", "line": 11}
+
+
+def test_deterministic_serialization():
+    """Same WorkflowGraph -> same JSON (serialize twice, assert equal)."""
+    nodes = [
+        ExtractedNode("b", "fb", 2),
+        ExtractedNode("a", "fa", 1),
+    ]
+    edges = [
+        ExtractedEdge("a", "b", 3),
+    ]
+    cond_edges = [
+        ExtractedConditionalEdge("b", "x", "a", 4),
+    ]
+    g = WorkflowGraph(
+        graph_id="x:0",
+        nodes=tuple(nodes),
+        edges=tuple(edges),
+        conditional_edges=tuple(cond_edges),
+        entry_point="a",
+    )
+    d1 = workflow_graph_to_dict(g)
+    d2 = workflow_graph_to_dict(g)
+    json1 = json.dumps(d1, sort_keys=True)
+    json2 = json.dumps(d2, sort_keys=True)
+    assert json1 == json2
+    assert d1 == d2
+
+
+def test_nodes_sorted_by_name_then_line():
+    """Nodes in serialized output are sorted by (name, line)."""
+    g = WorkflowGraph(
+        graph_id="x:0",
+        nodes=(
+            ExtractedNode("z", "fz", 1),
+            ExtractedNode("a", "fa", 2),
+            ExtractedNode("a", "fa2", 1),
+        ),
+        edges=(),
+        conditional_edges=(),
+        entry_point=None,
+    )
+    d = workflow_graph_to_dict(g)
+    names = [n["name"] for n in d["nodes"]]
+    assert names == ["a", "a", "z"]
+    assert d["nodes"][0]["line"] == 1 and d["nodes"][1]["line"] == 2
+
+
+def test_edges_sorted_by_source_target_line():
+    """Edges in serialized output are sorted by (source, target, line)."""
+    g = WorkflowGraph(
+        graph_id="x:0",
+        nodes=(),
+        edges=(
+            ExtractedEdge("b", "c", 2),
+            ExtractedEdge("a", "b", 1),
+        ),
+        conditional_edges=(),
+        entry_point=None,
+    )
+    d = workflow_graph_to_dict(g)
+    assert d["edges"][0]["source"] == "a"
+    assert d["edges"][1]["source"] == "b"
+
+
+def test_conditional_edges_sorted():
+    """Conditional edges in serialized output are sorted."""
+    g = WorkflowGraph(
+        graph_id="x:0",
+        nodes=(),
+        edges=(),
+        conditional_edges=(
+            ExtractedConditionalEdge("n", "y", "b", 2),
+            ExtractedConditionalEdge("n", "x", "a", 1),
+        ),
+        entry_point=None,
+    )
+    d = workflow_graph_to_dict(g)
+    labels = [e["condition_label"] for e in d["conditional_edges"]]
+    assert labels == ["x", "y"]
+
+
+def test_build_workflow_graph():
+    """build_workflow_graph produces WorkflowGraph from lists."""
+    nodes = [ExtractedNode("a", "f", 1)]
+    edges = [ExtractedEdge("a", "b", 2)]
+    cond = [ExtractedConditionalEdge("b", "ok", "a", 3)]
+    g = build_workflow_graph("id:0", nodes, edges, cond, "a")
+    assert g.graph_id == "id:0"
+    assert g.entry_point == "a"
+    assert len(g.nodes) == 1 and g.nodes[0].name == "a"
+    assert len(g.edges) == 1 and g.edges[0].target == "b"
+    assert len(g.conditional_edges) == 1 and g.conditional_edges[0].condition_label == "ok"
+
+
+def test_entry_point_null_serialized():
+    """entry_point None -> JSON null."""
+    g = WorkflowGraph(
+        graph_id="x:0",
+        nodes=(),
+        edges=(),
+        conditional_edges=(),
+        entry_point=None,
+    )
+    d = workflow_graph_to_dict(g)
+    assert d["entry_point"] is None
+    s = json.dumps(d, sort_keys=True)
+    assert '"entry_point": null' in s
+
+
+def test_empty_graph_roundtrip():
+    """Empty graph serializes to valid JSON with empty arrays."""
+    g = WorkflowGraph(
+        graph_id="empty:0",
+        nodes=(),
+        edges=(),
+        conditional_edges=(),
+        entry_point=None,
+    )
+    d = workflow_graph_to_dict(g)
+    assert d["nodes"] == []
+    assert d["edges"] == []
+    assert d["conditional_edges"] == []
+    parsed = json.loads(json.dumps(d, sort_keys=True))
+    assert parsed == d


### PR DESCRIPTION
## Summary
Documents Phase-1 scope and constraints for LangGraph workflow extraction so the project has a single source of truth for in-scope vs out-of-scope work.

## Changes
- Add/update scope document (`docs/phase1-scope.md`) covering:
  - Supported language(s): Python only, 3.10+
  - Supported framework(s): LangGraph core API (StateGraph, add_node, add_edge, add_conditional_edges, entry/exit, compile)
  - Analysis type: static-only (AST, import resolution, path discovery; no execution)
  - Output format(s): versioned JSON schema, optional diagram derived from JSON
- Explicitly out of scope: token estimation, cost modeling, runtime execution, non-LangGraph frameworks
- Lock decisions and acceptance criteria (scope documented, in/out of scope agreed)

## Acceptance criteria (from issue)
- [x] Scope documented
- [x] In-scope and out-of-scope agreed

Closes #10