### PR TITLE
Implement repository scanning rules and default ignores

### DIFF
--- a/noctyl/ingestion/__init__.py
+++ b/noctyl/ingestion/__init__.py
@@ -10,13 +10,19 @@ from noctyl.ingestion.edge_extractor import (
     extract_entry_points,
 )
 from noctyl.ingestion.node_extractor import extract_add_node_calls
+from noctyl.ingestion.repo_scanner import (
+    DEFAULT_IGNORE_DIRS,
+    discover_python_files,
+)
 from noctyl.ingestion.stategraph_tracker import (
     TrackedStateGraph,
     track_stategraph_instances,
 )
 
 __all__ = [
+    "DEFAULT_IGNORE_DIRS",
     "TrackedStateGraph",
+    "discover_python_files",
     "extract_add_conditional_edges",
     "extract_add_edge_calls",
     "extract_add_node_calls",

--- a/noctyl/ingestion/repo_scanner.py
+++ b/noctyl/ingestion/repo_scanner.py
@@ -1,0 +1,49 @@
+"""
+Repository file discovery: find Python files under a root path with default ignore rules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_IGNORE_DIRS: tuple[str, ...] = (
+    ".venv",
+    "venv",
+    "site-packages",
+    "tests",
+    ".git",
+    "__pycache__",
+)
+
+
+def discover_python_files(
+    root_path: Path | str,
+    *,
+    ignore_dirs: Sequence[str] | None = None,
+) -> list[Path]:
+    """
+    Discover all Python files under root_path, excluding paths that contain
+    any of the ignored directory names as a path segment.
+
+    Args:
+        root_path: Directory to scan (e.g. repo root).
+        ignore_dirs: Directory names to exclude. If None, use DEFAULT_IGNORE_DIRS.
+
+    Returns:
+        Sorted list of Paths to .py files (deterministic order).
+    """
+    root = Path(root_path).resolve()
+    if not root.is_dir():
+        return []
+
+    names_to_ignore = set(ignore_dirs if ignore_dirs is not None else DEFAULT_IGNORE_DIRS)
+    result: list[Path] = []
+
+    for path in root.rglob("*.py"):
+        if path.is_file() and not path.is_symlink():
+            parts = path.relative_to(root).parts
+            if not any(part in names_to_ignore for part in parts):
+                result.append(path)
+
+    return sorted(result)

--- a/tests/test_repo_scanner.py
+++ b/tests/test_repo_scanner.py
@@ -1,0 +1,88 @@
+"""Tests for repository file discovery and ignore rules."""
+
+import tempfile
+from pathlib import Path
+
+from noctyl.ingestion import DEFAULT_IGNORE_DIRS, discover_python_files
+
+
+def test_default_ignores():
+    """discover_python_files(root) excludes .venv, venv, site-packages, tests, .git, __pycache__."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "src").mkdir()
+        (root / "src" / "lib").mkdir()
+        (root / "src" / "app.py").write_text("# app")
+        (root / "src" / "lib" / "foo.py").write_text("# foo")
+
+        (root / ".venv").mkdir()
+        (root / ".venv" / "ignore.py").write_text("#")
+        (root / "venv").mkdir()
+        (root / "venv" / "x.py").write_text("#")
+        (root / "site-packages" / "x").mkdir(parents=True)
+        (root / "site-packages" / "x" / "ignore.py").write_text("#")
+        (root / "tests").mkdir()
+        (root / "tests" / "test_foo.py").write_text("#")
+        (root / ".git").mkdir()
+        (root / ".git" / "ignore.py").write_text("#")
+        (root / "src" / "__pycache__").mkdir()
+        (root / "src" / "__pycache__" / "bar.py").write_text("#")
+
+        result = discover_python_files(root)
+        result_rel = sorted(p.relative_to(root) for p in result)
+        assert result_rel == [
+            Path("src/app.py"),
+            Path("src/lib/foo.py"),
+        ]
+
+
+def test_custom_ignore_dirs():
+    """Custom ignore_dirs excludes only those directory names."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "src").mkdir()
+        (root / "src" / "app.py").write_text("#")
+        (root / "custom_skip").mkdir()
+        (root / "custom_skip" / "bar.py").write_text("#")
+
+        result = discover_python_files(root, ignore_dirs=("custom_skip",))
+        result_rel = sorted(p.relative_to(root) for p in result)
+        assert result_rel == [Path("src/app.py")]
+
+
+def test_determinism():
+    """Same root yields same sorted list when called twice."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "a").mkdir()
+        (root / "b").mkdir()
+        (root / "a" / "x.py").write_text("#")
+        (root / "b" / "y.py").write_text("#")
+
+        r1 = discover_python_files(root)
+        r2 = discover_python_files(root)
+        assert r1 == r2
+        assert r1 == sorted(r1)
+
+
+def test_empty_root():
+    """Root with no .py files or only ignored dirs returns empty list."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        assert discover_python_files(root) == []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "tests").mkdir()
+        (root / "tests" / "test_only.py").write_text("#")
+        assert discover_python_files(root) == []
+
+
+def test_default_ignore_dirs_constant():
+    """DEFAULT_IGNORE_DIRS includes required names from issue."""
+    assert ".venv" in DEFAULT_IGNORE_DIRS
+    assert "venv" in DEFAULT_IGNORE_DIRS
+    assert "site-packages" in DEFAULT_IGNORE_DIRS
+    assert "tests" in DEFAULT_IGNORE_DIRS
+    assert ".git" in DEFAULT_IGNORE_DIRS
+    assert "__pycache__" in DEFAULT_IGNORE_DIRS


### PR DESCRIPTION
## Summary
Implements Phase-1 repository scanning: discover Python files under a given root with safe default ignore rules so the ingestion pipeline only analyzes project code.

## Changes
- **Repo scanner** — New `noctyl/ingestion/repo_scanner.py`:
  - `discover_python_files(root_path, ignore_dirs=None)` returns a sorted list of `.py` paths under `root_path`, excluding any path that contains an ignored directory name as a segment.
  - `DEFAULT_IGNORE_DIRS`: `.venv`, `venv`, `site-packages`, `tests`, `.git`, `__pycache__` (issue defaults plus standard exclusions).
  - Symlink files are skipped; result is deterministic (sorted).
- **Exports** — `discover_python_files` and `DEFAULT_IGNORE_DIRS` exported from `noctyl.ingestion`.
- **Tests** — `tests/test_repo_scanner.py`: default ignores, custom `ignore_dirs`, determinism, empty root, and `DEFAULT_IGNORE_DIRS` contents.
- **Integration** — `test_repo_scanner_to_ingestion_to_workflow_graph` in `test_ingestion_integration.py`: temp tree with `src/workflow.py` and `tests/`; `discover_python_files` → per-file ingestion → WorkflowGraph → JSON; asserts `tests/` is excluded and one workflow graph is produced with expected structure.
- **Docs** — Repo scanning (file discovery) documented in `docs/flow-diagrams.md` §8: diagram, default ignore table, and API.

## Acceptance criteria (from issue)
- [x] Safe defaults implemented
- [x] Ignore rules documented

Closes #14