### PR TITLE
Handle partial or invalid LangGraph workflows (error handling)

### DIFF
--- a/noctyl/ingestion/__init__.py
+++ b/noctyl/ingestion/__init__.py
@@ -10,6 +10,7 @@ from noctyl.ingestion.edge_extractor import (
     extract_entry_points,
 )
 from noctyl.ingestion.node_extractor import extract_add_node_calls
+from noctyl.ingestion.pipeline import run_pipeline_on_directory
 from noctyl.ingestion.repo_scanner import (
     DEFAULT_IGNORE_DIRS,
     discover_python_files,
@@ -23,6 +24,7 @@ __all__ = [
     "DEFAULT_IGNORE_DIRS",
     "TrackedStateGraph",
     "discover_python_files",
+    "run_pipeline_on_directory",
     "extract_add_conditional_edges",
     "extract_add_edge_calls",
     "extract_add_node_calls",

--- a/noctyl/ingestion/pipeline.py
+++ b/noctyl/ingestion/pipeline.py
@@ -1,0 +1,66 @@
+"""
+Safe pipeline runner: discover files, read, ingest, build WorkflowGraph, serialize.
+Never raises for invalid or unreadable files; collects warnings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from noctyl.graph import build_workflow_graph, workflow_graph_to_dict
+from noctyl.ingestion.edge_extractor import (
+    extract_add_conditional_edges,
+    extract_add_edge_calls,
+    extract_entry_points,
+)
+from noctyl.ingestion.langgraph_detector import file_contains_langgraph
+from noctyl.ingestion.node_extractor import extract_add_node_calls
+from noctyl.ingestion.repo_scanner import discover_python_files
+from noctyl.ingestion.stategraph_tracker import track_stategraph_instances
+
+
+def run_pipeline_on_directory(
+    root_path: Path | str,
+) -> tuple[list[dict], list[str]]:
+    """
+    Run the full pipeline on a directory: discover .py files, read each, ingest,
+    build WorkflowGraph per graph, serialize to dict. Does not raise for
+    unreadable or invalid files; skips with a warning.
+
+    Returns:
+        (list of workflow dicts from workflow_graph_to_dict, list of warning strings).
+    """
+    root = Path(root_path).resolve()
+    paths = discover_python_files(root)
+    results: list[dict] = []
+    warnings: list[str] = []
+
+    for path in paths:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            warnings.append(f"{path}: could not read")
+            continue
+
+        file_path = str(path.relative_to(root))
+        if not file_contains_langgraph(source, file_path):
+            continue
+
+        tracked = track_stategraph_instances(source, file_path)
+        entry_by_graph, entry_warnings = extract_entry_points(source, file_path, tracked)
+        for w in entry_warnings:
+            warnings.append(w)
+
+        for t in tracked:
+            nodes = extract_add_node_calls(source, file_path, tracked).get(t.graph_id, [])
+            edges = extract_add_edge_calls(source, file_path, tracked).get(t.graph_id, [])
+            cond = extract_add_conditional_edges(source, file_path, tracked).get(
+                t.graph_id, []
+            )
+            entry_point = entry_by_graph.get(t.graph_id)
+            wg = build_workflow_graph(
+                t.graph_id, nodes, edges, cond, entry_point
+            )
+            results.append(workflow_graph_to_dict(wg))
+
+    return (results, warnings)


### PR DESCRIPTION
## Summary
Introduces the internal workflow graph model and a deterministic JSON serialization format so ingestion output has a stable, versioned contract.

## Changes
- **Graph model** — `noctyl/graph/graph.py`: `WorkflowGraph` dataclass (graph_id, nodes, edges, conditional_edges, entry_point, schema_version); `build_workflow_graph(...)` builds from ingestion outputs; `workflow_graph_to_dict(g)` returns a JSON-serializable dict with deterministic list ordering (nodes by name/line, edges by source/target/line, conditional_edges by source/condition_label/target/line).
- **JSON Schema** — `noctyl/graph/schema.json`: defines the serialized document shape (schema_version, graph_id, entry_point, nodes, edges, conditional_edges).
- **Exports** — `noctyl/graph/__init__.py`: WorkflowGraph, build_workflow_graph, workflow_graph_to_dict (and related types).
- **Tests** — `tests/test_graph_schema.py`: structure of workflow_graph_to_dict, deterministic serialization (same graph → same JSON), sort order for nodes/edges/conditional_edges, build_workflow_graph, entry_point null handling, empty graph round-trip.
- **Integration** — `test_ingestion_to_workflow_graph_and_deterministic_json` in test_ingestion_integration.py: ingestion → build_workflow_graph → workflow_graph_to_dict → JSON; asserts schema fields and determinism.

## Requirements (from issue)
- Nodes — included in WorkflowGraph and serialized dict
- Directed edges — edges and conditional_edges in model and schema
- Entry point — entry_point field (nullable) in model and schema

## Acceptance criteria
- [x] JSON schema defined (`noctyl/graph/schema.json`)
- [x] Deterministic serialization (sorted lists, stable output)

Closes #8s.