### PR TITLE
Handle partial or invalid LangGraph workflows (error handling)

### DIFF
--- a/docs/flow-diagrams.md
+++ b/docs/flow-diagrams.md
@@ -42,6 +42,7 @@ flowchart LR
     OutEdges[dict graph_id to edges]
     OutCondEdges[dict graph_id to conditional edges]
     EntryOut[entry_by_graph and warnings]
+    OutTerminal[terminal_nodes]
   end
 ```
 
@@ -51,7 +52,7 @@ flowchart LR
 2. **stategraph_tracker** — Find every `StateGraph(...)` and track variable name and `graph_id` per instance.
 3. **node_extractor** — For each tracked graph, find `add_node(name, callable)` calls whose receiver resolves to that graph; emit `ExtractedNode(name, callable_ref, line)` per graph. Uses shared **receiver_resolution** (alias map + resolve_receiver).
 4. **edge_extractor** — For each tracked graph: (a) `add_edge(source, target)` -> `ExtractedEdge(source, target, line)`; (b) `add_conditional_edges(source, path, path_map)` with dict-literal path_map -> one `ExtractedConditionalEdge(source, condition_label, target, line)` per path_map entry. END as target supported. (c) **Entry point:** `extract_entry_points` returns `(entry_by_graph, warnings)` from `set_entry_point(name)` or fallback from single `add_edge(START, target)`; warning when missing. Same receiver resolution.
-5. **Graph schema:** Ingestion outputs (nodes, edges, conditional_edges, entry_point per graph_id) are assembled into a **WorkflowGraph** via `build_workflow_graph`; **workflow_graph_to_dict** produces a deterministic JSON-serializable dict; JSON Schema in `noctyl/graph/schema.json` describes the serialized shape.
+5. **Graph schema:** Ingestion outputs (nodes, edges, conditional_edges, entry_point per graph_id) are assembled into a **WorkflowGraph** via `build_workflow_graph`; **workflow_graph_to_dict** produces a deterministic JSON-serializable dict; JSON Schema in `noctyl/graph/schema.json` describes the serialized shape. **END and terminal nodes:** END is represented as target `"END"` in edges and conditional_edges; `terminal_nodes` is a first-class list of node names that have an outgoing edge or conditional edge to END (distinguishable without scanning edges).
 
 ---
 
@@ -69,7 +70,7 @@ flowchart LR
   end
   subgraph graph [Graph]
     WG[WorkflowGraph]
-    WG -->|workflow_graph_to_dict| Dict[JSON-serializable dict]
+    WG -->|workflow_graph_to_dict| Dict[JSON dict with nodes edges entry_point terminal_nodes]
     Dict -->|json.dumps sort_keys| JSON[JSON string]
   end
   Nodes --> WG
@@ -79,9 +80,9 @@ flowchart LR
 ```
 
 **Data flow:**
-- **build_workflow_graph(graph_id, nodes, edges, conditional_edges, entry_point)** builds a WorkflowGraph (schema_version, graph_id, nodes, edges, conditional_edges, entry_point).
-- **workflow_graph_to_dict(g)** returns a dict with deterministic list ordering (nodes by name/line, edges by source/target/line, conditional_edges by source/condition_label/target/line).
-- **JSON Schema:** `noctyl/graph/schema.json` defines the serialized document shape (nodes, directed edges, entry_point).
+- **build_workflow_graph(graph_id, nodes, edges, conditional_edges, entry_point)** builds a WorkflowGraph (schema_version, graph_id, nodes, edges, conditional_edges, entry_point, terminal_nodes). `terminal_nodes` is derived from edges and conditional_edges (sources where target is `"END"`).
+- **workflow_graph_to_dict(g)** returns a dict with deterministic list ordering (nodes by name/line, edges by source/target/line, conditional_edges by source/condition_label/target/line). The serialized dict includes **terminal_nodes** (sorted list of node names that transition to END).
+- **JSON Schema:** `noctyl/graph/schema.json` defines the serialized document shape (nodes, directed edges, entry_point, terminal_nodes).
 
 ---
 

--- a/noctyl/graph/schema.json
+++ b/noctyl/graph/schema.json
@@ -4,7 +4,7 @@
   "title": "WorkflowGraph",
   "description": "Noctyl Phase-1 workflow graph: nodes, directed edges, entry point.",
   "type": "object",
-  "required": ["schema_version", "graph_id", "entry_point", "nodes", "edges", "conditional_edges"],
+  "required": ["schema_version", "graph_id", "entry_point", "terminal_nodes", "nodes", "edges", "conditional_edges"],
   "properties": {
     "schema_version": {
       "type": "string",
@@ -17,6 +17,11 @@
     "entry_point": {
       "oneOf": [{ "type": "string" }, { "type": "null" }],
       "description": "Entry node name, or null if missing/unknown."
+    },
+    "terminal_nodes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Node names that have an outgoing edge or conditional edge to END."
     },
     "nodes": {
       "type": "array",

--- a/tests/test_ingestion_integration.py
+++ b/tests/test_ingestion_integration.py
@@ -137,6 +137,8 @@ graph.add_conditional_edges("b", router, {"next": "a", "done": END})
     assert d["schema_version"] == "1.0"
     assert d["graph_id"] == graph_id
     assert d["entry_point"] == "a"
+    assert "terminal_nodes" in d
+    assert "b" in d["terminal_nodes"], "b has conditional edge to END"
     assert len(d["nodes"]) == 2
     assert len(d["edges"]) == 2
     assert len(d["conditional_edges"]) == 2
@@ -150,6 +152,7 @@ graph.add_conditional_edges("b", router, {"next": "a", "done": END})
 
     parsed = json.loads(json1)
     assert parsed["entry_point"] == "a"
+    assert "b" in parsed["terminal_nodes"]
     assert len(parsed["nodes"]) == 2
     assert len(parsed["conditional_edges"]) == 2
 
@@ -334,6 +337,7 @@ graph.add_conditional_edges("b", router, {"next": "a", "done": END})
         assert len(all_graphs) >= 1
         d = all_graphs[0]
         assert d["entry_point"] == "a"
+        assert "terminal_nodes" in d and "b" in d["terminal_nodes"]
         assert len(d["nodes"]) == 2
         assert len(d["edges"]) == 2
         assert len(d["conditional_edges"]) == 2
@@ -363,6 +367,7 @@ graph.add_edge(START, "a")
 
         assert len(results) >= 1
         assert results[0]["entry_point"] == "a"
+        assert "terminal_nodes" in results[0]
         assert any("could not read" in w for w in warnings)
 
 


### PR DESCRIPTION
## Summary
Defines behaviour for partially analysable or invalid LangGraph code: best-effort, warn and continue, so the tool does not crash and emits clear warnings.

## Strategy
**Best-effort.** Invalid or unsupported code: warn and continue; skip and report; emit partial when possible. No fail-fast (aligned with [phase1-scope.md](docs/phase1-scope.md) §8).

## Changes
- **Safe pipeline runner** — `noctyl/ingestion/pipeline.py`: `run_pipeline_on_directory(root_path)` runs discover → read each file → ingest → build WorkflowGraph → to_dict. Catches `OSError` and `UnicodeDecodeError` when reading files; appends `"{path}: could not read"` to warnings and skips that file. Does not raise for invalid or unreadable files.
- **Library APIs** — All ingestion entry points that take `source: str` already catch `SyntaxError` and return safe empty/false values (detector, tracker, node/edge extractors, entry_points).
- **Warnings** — Entry point: `extract_entry_points` returns warnings (e.g. "graph_id X: no entry point detected", "ambiguous entry"). Pipeline: file read failures add "path: could not read".
- **Docs** — [docs/flow-diagrams.md](docs/flow-diagrams.md) §9: error-handling strategy, where the library does not crash, warning formats, and a diagram for `run_pipeline_on_directory` (read errors → warn and skip).
- **Tests** — `test_run_pipeline_on_directory_unreadable_file_does_not_crash` (unreadable file → no crash, warning, valid file still yields a graph); `test_run_pipeline_on_directory_syntax_error_only_does_not_crash` (syntax-only file → empty results, no crash).

## Acceptance criteria (from issue)
- [x] **Tool does not crash** — Guaranteed by `run_pipeline_on_directory` catching read errors and by existing APIs catching SyntaxError.
- [x] **Clear warnings emitted** — Documented in §9; entry_point warnings and "could not read" for file I/O failures.

Closes #6