### PR TITLE
Detect LangGraph workflows in repository

### DIFF
--- a/tests/fixtures/golden/README.md
+++ b/tests/fixtures/golden/README.md
@@ -1,0 +1,17 @@
+# Golden LangGraph fixtures (Phase-1)
+
+Canonical examples used to validate graph extraction. Each file is a minimal, self-contained LangGraph workflow. Tests in `tests/test_golden.py` run `run_pipeline_on_directory` on this directory and assert the extracted graph structure.
+
+## Required cases (issue)
+
+- **linear_workflow.py** — Linear: START -> A -> B -> END.
+- **conditional_loop.py** — Conditional loop: START -> A, A conditional to loop/next/done (one target END).
+- **end_termination.py** — END only: START -> A -> END.
+
+## Additional cases
+
+- **multiple_graphs.py** — Two StateGraphs in one file; validates correct attribution per graph_id.
+- **set_entry_point_explicit.py** — Uses `set_entry_point("b")`; validates explicit entry point.
+- **mixed_linear_conditional.py** — Linear chain then conditional at end (START -> A -> B, B conditional to C or END).
+- **single_node.py** — Single node A, START -> A -> END.
+- **multiple_conditional_nodes.py** — Nodes A and B each have conditional_edges; both can transition to END.

--- a/tests/fixtures/golden/conditional_loop.py
+++ b/tests/fixtures/golden/conditional_loop.py
@@ -1,0 +1,13 @@
+"""Golden: conditional loop START -> A, A -> loop/next/done."""
+from langgraph.graph import StateGraph, START, END
+
+def fa(x): return x
+def fb(x): return x
+def router(x): return "done"
+
+graph = StateGraph(dict)
+graph.add_node("a", fa)
+graph.add_node("b", fb)
+graph.add_edge(START, "a")
+graph.add_conditional_edges("a", router, {"loop": "a", "next": "b", "done": END})
+graph.add_edge("b", END)

--- a/tests/fixtures/golden/end_termination.py
+++ b/tests/fixtures/golden/end_termination.py
@@ -1,0 +1,9 @@
+"""Golden: END termination only START -> A -> END."""
+from langgraph.graph import StateGraph, START, END
+
+def fa(x): return x
+
+graph = StateGraph(dict)
+graph.add_node("a", fa)
+graph.add_edge(START, "a")
+graph.add_edge("a", END)

--- a/tests/fixtures/golden/linear_workflow.py
+++ b/tests/fixtures/golden/linear_workflow.py
@@ -1,0 +1,12 @@
+"""Golden: linear workflow START -> A -> B -> END."""
+from langgraph.graph import StateGraph, START, END
+
+def fa(x): return x
+def fb(x): return x
+
+graph = StateGraph(dict)
+graph.add_node("a", fa)
+graph.add_node("b", fb)
+graph.add_edge(START, "a")
+graph.add_edge("a", "b")
+graph.add_edge("b", END)

--- a/tests/fixtures/golden/mixed_linear_conditional.py
+++ b/tests/fixtures/golden/mixed_linear_conditional.py
@@ -1,0 +1,16 @@
+"""Golden: linear chain then conditional at end START -> A -> B, B -> C or END."""
+from langgraph.graph import StateGraph, START, END
+
+def fa(x): return x
+def fb(x): return x
+def fc(x): return x
+def router(x): return "out"
+
+graph = StateGraph(dict)
+graph.add_node("a", fa)
+graph.add_node("b", fb)
+graph.add_node("c", fc)
+graph.add_edge(START, "a")
+graph.add_edge("a", "b")
+graph.add_conditional_edges("b", router, {"next": "c", "done": END})
+graph.add_edge("c", END)

--- a/tests/fixtures/golden/multiple_conditional_nodes.py
+++ b/tests/fixtures/golden/multiple_conditional_nodes.py
@@ -1,0 +1,14 @@
+"""Golden: two nodes each with conditional_edges to END."""
+from langgraph.graph import StateGraph, START, END
+
+def fa(x): return x
+def fb(x): return x
+def ra(x): return "stop"
+def rb(x): return "stop"
+
+graph = StateGraph(dict)
+graph.add_node("a", fa)
+graph.add_node("b", fb)
+graph.add_edge(START, "a")
+graph.add_conditional_edges("a", ra, {"go": "b", "stop": END})
+graph.add_conditional_edges("b", rb, {"go": "a", "stop": END})

--- a/tests/fixtures/golden/multiple_graphs.py
+++ b/tests/fixtures/golden/multiple_graphs.py
@@ -1,0 +1,21 @@
+"""Golden: two StateGraphs in one file."""
+from langgraph.graph import StateGraph, START, END
+
+def f1(x): return x
+def f2(x): return x
+def g1(x): return x
+def g2(x): return x
+
+graph1 = StateGraph(dict)
+graph1.add_node("x", f1)
+graph1.add_node("y", f2)
+graph1.add_edge(START, "x")
+graph1.add_edge("x", "y")
+graph1.add_edge("y", END)
+
+graph2 = StateGraph(dict)
+graph2.add_node("p", g1)
+graph2.add_node("q", g2)
+graph2.add_edge(START, "p")
+graph2.add_edge("p", "q")
+graph2.add_edge("q", END)

--- a/tests/fixtures/golden/set_entry_point_explicit.py
+++ b/tests/fixtures/golden/set_entry_point_explicit.py
@@ -1,0 +1,12 @@
+"""Golden: explicit set_entry_point instead of START edge."""
+from langgraph.graph import StateGraph, START, END
+
+def fa(x): return x
+def fb(x): return x
+
+graph = StateGraph(dict)
+graph.add_node("a", fa)
+graph.add_node("b", fb)
+graph.add_edge("a", "b")
+graph.add_edge("b", END)
+graph.set_entry_point("b")

--- a/tests/fixtures/golden/single_node.py
+++ b/tests/fixtures/golden/single_node.py
@@ -1,0 +1,9 @@
+"""Golden: single node START -> A -> END."""
+from langgraph.graph import StateGraph, START, END
+
+def fa(x): return x
+
+graph = StateGraph(dict)
+graph.add_node("a", fa)
+graph.add_edge(START, "a")
+graph.add_edge("a", END)

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -1,0 +1,122 @@
+"""
+Golden tests: canonical LangGraph fixtures and validated graph extraction.
+
+Runs run_pipeline_on_directory on tests/fixtures/golden/ and asserts expected
+structure for each case (linear, conditional loop, END termination, etc.).
+"""
+
+from pathlib import Path
+
+from noctyl.ingestion import run_pipeline_on_directory
+
+GOLDEN_DIR = Path(__file__).resolve().parent / "fixtures" / "golden"
+
+
+def _node_names(d):
+    return {n["name"] for n in d["nodes"]}
+
+
+def _find_graph(results, predicate):
+    for g in results:
+        if predicate(g):
+            return g
+    return None
+
+
+def test_golden_pipeline_runs():
+    """run_pipeline_on_directory on golden dir returns results and does not crash."""
+    results, warnings = run_pipeline_on_directory(GOLDEN_DIR)
+    # 8 files, multiple_graphs.py yields 2 graphs -> 9 graphs total
+    assert len(results) >= 8, "expected at least 8 graphs (7 files + 2 from multiple_graphs)"
+    assert all("schema_version" in g and "nodes" in g for g in results)
+
+
+def test_golden_linear_workflow():
+    """Linear: START -> A -> B -> END."""
+    results, _ = run_pipeline_on_directory(GOLDEN_DIR)
+    g = _find_graph(results, lambda d: _node_names(d) == {"a", "b"} and not d["conditional_edges"] and d["entry_point"] == "a" and ("b", "END") in [(e["source"], e["target"]) for e in d["edges"]])
+    assert g is not None
+    assert g["entry_point"] == "a"
+    assert _node_names(g) == {"a", "b"}
+    assert g["terminal_nodes"] == ["b"]
+    assert len(g["conditional_edges"]) == 0
+    edges_sources_targets = [(e["source"], e["target"]) for e in g["edges"]]
+    assert ("a", "b") in edges_sources_targets
+    assert ("b", "END") in edges_sources_targets
+
+
+def test_golden_conditional_loop():
+    """Conditional loop: A has conditional_edges loop/next/done, one target END."""
+    results, _ = run_pipeline_on_directory(GOLDEN_DIR)
+    g = _find_graph(results, lambda d: len(d["conditional_edges"]) >= 1 and any(e["target"] == "END" for e in d["conditional_edges"]) and "a" in _node_names(d) and d["entry_point"] == "a")
+    assert g is not None
+    assert g["entry_point"] == "a"
+    cond_labels = {e["condition_label"] for e in g["conditional_edges"]}
+    assert "done" in cond_labels
+    assert "a" in g["terminal_nodes"] or "b" in g["terminal_nodes"]
+
+
+def test_golden_end_termination():
+    """END termination only: single node A, START -> A -> END."""
+    results, _ = run_pipeline_on_directory(GOLDEN_DIR)
+    g = _find_graph(results, lambda d: _node_names(d) == {"a"} and len(d["nodes"]) == 1 and d["entry_point"] == "a" and d["terminal_nodes"] == ["a"] and any(e["target"] == "END" for e in d["edges"]))
+    assert g is not None
+    assert g["entry_point"] == "a"
+    assert g["terminal_nodes"] == ["a"]
+    assert len(g["edges"]) >= 2  # START->a, a->END
+
+
+def test_golden_multiple_graphs():
+    """One file yields two graphs with distinct node sets."""
+    results, _ = run_pipeline_on_directory(GOLDEN_DIR)
+    by_nodes = {}
+    for g in results:
+        names = frozenset(_node_names(g))
+        by_nodes.setdefault(names, []).append(g)
+    # graph1: x,y  graph2: p,q
+    assert frozenset({"x", "y"}) in by_nodes
+    assert frozenset({"p", "q"}) in by_nodes
+    assert len(by_nodes[frozenset({"x", "y"})]) >= 1
+    assert len(by_nodes[frozenset({"p", "q"})]) >= 1
+
+
+def test_golden_set_entry_point_explicit():
+    """Explicit set_entry_point('b') -> entry_point is b."""
+    results, _ = run_pipeline_on_directory(GOLDEN_DIR)
+    g = _find_graph(results, lambda d: d["entry_point"] == "b" and _node_names(d) == {"a", "b"})
+    assert g is not None
+    assert g["entry_point"] == "b"
+
+
+def test_golden_mixed_linear_conditional():
+    """Linear chain + conditional from last node; terminal_nodes from conditional to END."""
+    results, _ = run_pipeline_on_directory(GOLDEN_DIR)
+    g = _find_graph(results, lambda d: "b" in _node_names(d) and "c" in _node_names(d) and len(d["conditional_edges"]) >= 1 and len(d["edges"]) >= 2)
+    assert g is not None
+    assert "b" in g["terminal_nodes"]
+    cond_sources = {e["source"] for e in g["conditional_edges"]}
+    assert "b" in cond_sources
+
+
+def test_golden_single_node():
+    """Single node a: entry_point a, terminal_nodes [a]."""
+    results, _ = run_pipeline_on_directory(GOLDEN_DIR)
+    g = _find_graph(results, lambda d: len(d["nodes"]) == 1 and _node_names(d) == {"a"} and d["terminal_nodes"] == ["a"])
+    assert g is not None
+    assert g["entry_point"] == "a"
+
+
+def test_golden_multiple_conditional_nodes():
+    """Two nodes each with conditional_edges; both can transition to END."""
+    results, _ = run_pipeline_on_directory(GOLDEN_DIR)
+    # Must have conditional_edges from two different sources (a and b)
+    g = _find_graph(
+        results,
+        lambda d: _node_names(d) == {"a", "b"}
+        and len(d["conditional_edges"]) >= 2
+        and {e["source"] for e in d["conditional_edges"]} == {"a", "b"},
+    )
+    assert g is not None
+    cond_sources = {e["source"] for e in g["conditional_edges"]}
+    assert cond_sources == {"a", "b"}
+    assert set(g["terminal_nodes"]) == {"a", "b"}


### PR DESCRIPTION
## Summary
Implements detection of LangGraph usage in Python files so the pipeline can skip non-LangGraph code and only run full extraction on files that define workflows.

## Detection signals
- **Imports from `langgraph.graph`** — `has_langgraph_import(source)` does a single AST pass over imports and returns True if the file imports `langgraph.graph` (including aliased and qualified imports).
- **Instantiation of `StateGraph`** — `file_contains_langgraph(source, file_path)` uses `track_stategraph_instances` and returns True iff at least one `StateGraph(...)` is found. Invalid or non-LangGraph files return False and are safely ignored.

## Open questions (resolved)
- **Aliased imports** — Handled: detector and stategraph_tracker support aliased and qualified imports (e.g. `from langgraph.graph import StateGraph as SG`; tracker resolves `SG` to StateGraph).
- **Skip non-LangGraph early** — Yes: use `has_langgraph_import` as a fast path to skip files with no LangGraph import before running full tracking.

## Changes
- **noctyl/ingestion/langgraph_detector.py** — `has_langgraph_import(source)`, `file_contains_langgraph(source, file_path)`; both catch SyntaxError and return False / rely on tracker returning [] so no crash on invalid input.
- **Exports** — Both functions exported from `noctyl.ingestion`.
- **Tests** — tests/test_langgraph_detector.py: no import, import only (no StateGraph), with instantiation, multiple instances, aliased import, qualified name, syntax error, empty source; integration with tracker.
- **Usage** — Pipeline and integration tests use these to skip files that do not contain LangGraph before running full extraction.

## Acceptance criteria
- [x] **AST-based detection implemented** — Imports and StateGraph calls detected via AST (langgraph_detector + stategraph_tracker).
- [x] **Non-LangGraph files safely ignored** — No import or no StateGraph → False / []; syntax error → False / []; no uncaught exceptions.

Closes #9