### PR TITLE
Refactor installation script and update project name from Noctyl to D…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Noctyl
+# Deep-Scout (formerly Noctyl)
 
 <p align="center">
   <img src="https://media.giphy.com/media/3o7abKhOpu0NwenH3O/giphy.gif" width="120" alt="owl" />
@@ -15,15 +15,15 @@
 
 **Static Token Usage Estimator for Multi-Agent AI Workflows**
 
-Noctyl is a static analysis tool that **estimates token usage and cost for multi-agent AI workflows *before execution***.  
+Deep-Scout is a static analysis tool that **estimates token usage and cost for multi-agent AI workflows *before execution***.  
 It analyzes a code repository, constructs a workflow graph, and produces structured reports that can be consumed by humans *and* AI assistants (Claude, Codex, Copilot, Cursor).
 
-> Noctyl does **not** execute agents, call LLM APIs, or burn tokens.  
+> Deep-Scout does **not** execute agents, call LLM APIs, or burn tokens.  
 > It provides **pre-run intelligence** for cost, safety, and efficiency.
 
 ---
 
-## Why Noctyl?
+## Why Deep-Scout?
 
 Agentic systems often fail silently due to:
 
@@ -32,7 +32,7 @@ Agentic systems often fail silently due to:
 - Hidden retry costs
 - Poor agent decomposition
 
-Noctyl answers:
+Deep-Scout answers:
 
 - *How many tokens will this workflow burn before I run it?*
 - *Where does token growth originate?*
@@ -71,14 +71,14 @@ Noctyl answers:
 
 ---
 
-## What Noctyl Is NOT
+## What Deep-Scout Is NOT
 
 - ❌ Not a runtime token monitor
 - ❌ Not a tracing or observability tool
 - ❌ Not an LLM wrapper
 - ❌ Not tied to any single agent framework
 
-Noctyl runs **before execution**, not during or after.
+Deep-Scout runs **before execution**, not during or after.
 
 ---
 
@@ -90,23 +90,38 @@ Noctyl runs **before execution**, not during or after.
 curl -fsSL https://raw.githubusercontent.com/xZiro-Lab/Noctyl/main/install.sh | bash
 ```
 
+During the transition, the installer URL remains on the current repository path and installs the new `deep-scout` package first with a compatibility fallback.
+
 ### CLI Usage
 
-After installation, use the `noctyl estimate` command to estimate token usage:
+After installation, use the `deep-scout estimate` command to estimate token usage:
 
 ```bash
 # Basic usage (default profile)
-noctyl estimate ./my_project
+deep-scout estimate ./my_project
 
 # With custom model profile
-noctyl estimate ./my_project --profile profiles/gpt-4o.yaml
+deep-scout estimate ./my_project --profile profiles/gpt-4o.yaml
 
 # Save output to file
-noctyl estimate ./my_project --output estimates.json
+deep-scout estimate ./my_project --output estimates.json
 
 # With profile and output file
-noctyl estimate ./my_project --profile profiles/gpt-4o.yaml --output estimates.json
+deep-scout estimate ./my_project --profile profiles/gpt-4o.yaml --output estimates.json
 ```
+
+`noctyl estimate ...` remains available for one compatibility release and prints a deprecation warning.
+
+## Migration (Noctyl -> Deep-Scout)
+
+- Primary command is now `deep-scout`.
+- Legacy command `noctyl` is still supported for this release.
+- Python import namespace remains `noctyl` in this phase to avoid breaking code.
+
+### Deprecation timeline
+
+- Current release: both `deep-scout` and `noctyl` CLI commands work.
+- Next release: `noctyl` CLI alias is removed; `deep-scout` remains the only supported CLI command.
 
 **Profile File Format (YAML):**
 ```yaml
@@ -135,14 +150,14 @@ model_profiles:
 ## Project structure
 
 ```
-noctyl/
+deep-scout/
 ├── README.md
 ├── LICENSE
 ├── pyproject.toml
 ├── install.sh
 ├── .gitignore
 │
-├── noctyl/                         # Core package
+├── noctyl/                         # Core package (kept as-is for compatibility)
 │   ├── __init__.py
 │   │
 │   ├── ingestion/                  # Repo scanning, detection & extraction (Phase 1)
@@ -184,7 +199,7 @@ noctyl/
 │       ├── token_modeler.py       # TokenModeler class orchestrating the pipeline
 │       └── profile_loader.py      # YAML profile loading and defaults
 │   │
-│   └── cli.py                       # CLI command interface (noctyl estimate)
+│   └── cli.py                       # CLI command interface (deep-scout estimate, legacy noctyl alias)
 │
 ├── tests/                          # 493+ tests (pytest)
 │   ├── fixtures/golden/            # 8 canonical LangGraph fixture files
@@ -245,4 +260,4 @@ noctyl/
 
 ---
 
-*Noctyl — know your token usage before you run.*
+*Deep-Scout (formerly Noctyl) — know your token usage before you run.*

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 set -e
-pip install "git+https://github.com/xZiro-Lab/Noctyl.git@main"
+if pip install deep-scout; then
+  echo "Installed deep-scout."
+else
+  echo "deep-scout package unavailable, falling back to legacy Noctyl source install."
+  pip install "git+https://github.com/xZiro-Lab/Noctyl.git@main"
+fi

--- a/noctyl/cli.py
+++ b/noctyl/cli.py
@@ -1,5 +1,5 @@
 """
-Noctyl CLI: command-line interface for token estimation.
+Deep-Scout CLI: command-line interface for token estimation.
 """
 
 import argparse
@@ -10,6 +10,20 @@ from pathlib import Path
 from noctyl.ingestion import run_pipeline_on_directory
 
 
+def _is_legacy_noctyl_invocation(argv0: str) -> bool:
+    """Return True when invoked via the legacy `noctyl` command name."""
+    return Path(argv0).stem.lower() == "noctyl"
+
+
+def _print_legacy_noctyl_warning() -> None:
+    """Print a non-breaking deprecation warning for legacy command usage."""
+    print(
+        "Warning: `noctyl` CLI is deprecated and will be removed in the next release. "
+        "Please migrate to `deep-scout`.",
+        file=sys.stderr,
+    )
+
+
 def main() -> int:
     """
     Main CLI entry point.
@@ -18,7 +32,8 @@ def main() -> int:
         Exit code: 0 on success, 1 on errors/warnings
     """
     parser = argparse.ArgumentParser(
-        description="Noctyl: Static token usage estimator for LangGraph workflows"
+        description="Deep-Scout: Static token usage estimator for LangGraph workflows "
+        "(formerly Noctyl)"
     )
     subparsers = parser.add_subparsers(dest="command", help="Commands")
     
@@ -35,6 +50,9 @@ def main() -> int:
     )
     
     args = parser.parse_args()
+
+    if _is_legacy_noctyl_invocation(sys.argv[0]):
+        _print_legacy_noctyl_warning()
     
     if args.command == "estimate":
         return _run_estimate(args.path, args.profile, args.output)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "noctyl"
+name = "deep-scout"
 version = "0.1.0"
 description = "Static token usage estimator for multi-agent AI workflows"
 readme = "README.md"
@@ -13,6 +13,7 @@ dependencies = [
 ]
 
 [project.scripts]
+deep-scout = "noctyl.cli:main"
 noctyl = "noctyl.cli:main"
 
 [project.optional-dependencies]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,68 @@ def _run_cli(args: list[str]) -> tuple[int, str, str]:
     return result.returncode, result.stdout, result.stderr
 
 
+def _run_python_snippet(code: str) -> tuple[int, str, str]:
+    """Run an inline Python snippet and return (exit_code, stdout, stderr)."""
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, encoding="utf-8"
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def test_dual_cli_entrypoints_present_in_pyproject():
+    """Both deep-scout and noctyl console scripts are declared."""
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    content = pyproject_path.read_text(encoding="utf-8")
+
+    assert 'deep-scout = "noctyl.cli:main"' in content
+    assert 'noctyl = "noctyl.cli:main"' in content
+
+
+def test_detect_legacy_noctyl_invocation():
+    """Legacy command detection works for common executable names."""
+    code = """
+import sys
+import types
+
+stub = types.ModuleType("noctyl.ingestion")
+stub.run_pipeline_on_directory = lambda *args, **kwargs: ([], [])
+sys.modules["noctyl.ingestion"] = stub
+
+import noctyl.cli as cli
+
+print(cli._is_legacy_noctyl_invocation("noctyl"))
+print(cli._is_legacy_noctyl_invocation("noctyl.exe"))
+print(cli._is_legacy_noctyl_invocation("deep-scout"))
+"""
+    exit_code, stdout, stderr = _run_python_snippet(code)
+
+    assert exit_code == 0
+    assert stderr == ""
+    assert stdout.splitlines() == ["True", "True", "False"]
+
+
+def test_print_legacy_noctyl_warning():
+    """Legacy warning explicitly guides users to deep-scout."""
+    code = """
+import sys
+import types
+
+stub = types.ModuleType("noctyl.ingestion")
+stub.run_pipeline_on_directory = lambda *args, **kwargs: ([], [])
+sys.modules["noctyl.ingestion"] = stub
+
+import noctyl.cli as cli
+
+cli._print_legacy_noctyl_warning()
+"""
+    exit_code, stdout, stderr = _run_python_snippet(code)
+
+    assert exit_code == 0
+    assert stdout == ""
+    assert "deprecated" in stderr.lower()
+    assert "deep-scout" in stderr
+
+
 def test_cli_estimate_basic():
     """Basic estimate command works."""
     source = """


### PR DESCRIPTION
…eep-Scout. The installer now attempts to install the deep-scout package first, with a fallback to the legacy Noctyl source if unavailable. Update README and CLI references to reflect the new name and provide deprecation warnings for the legacy command. Ensure both CLI commands are available during the transition for compatibility.